### PR TITLE
Small modifications to allow Python3.4 instalation

### DIFF
--- a/gizflo/__init__.py
+++ b/gizflo/__init__.py
@@ -1,6 +1,6 @@
 
 __version__ = "0.0.2"
-__version_info__ = tuple([ int(num) for num in __version__.split('.')])
+__version_info__ = tuple([int(num) for num in __version__.split('.')])
 
-from boards import get_board
-import toolchain as flo
+from .boards import get_board
+from . import toolchain as flo

--- a/gizflo/_fpga.py
+++ b/gizflo/_fpga.py
@@ -22,9 +22,9 @@ from copy import copy
 
 import myhdl
 
-from extintf import Port
-from extintf import Clock
-from extintf import Reset
+from .extintf import Port
+from .extintf import Clock
+from .extintf import Reset
 
 
 class _fpga(object):

--- a/gizflo/boards/__init__.py
+++ b/gizflo/boards/__init__.py
@@ -1,2 +1,2 @@
 
-from _get_board import get_board
+from ._get_board import get_board

--- a/gizflo/boards/_get_board.py
+++ b/gizflo/boards/_get_board.py
@@ -16,9 +16,9 @@
 from __future__ import division
 from __future__ import print_function
 
-from xilinx._xula import Xula, Xula2
-from xilinx._papilio import Pone
-from altera._de0nano import DE0Nano
+from .xilinx._xula import Xula, Xula2
+from .xilinx._papilio import Pone
+from .altera._de0nano import DE0Nano
 
 xbrd = {
     'xula': Xula,

--- a/gizflo/boards/xilinx/_xula.py
+++ b/gizflo/boards/xilinx/_xula.py
@@ -29,17 +29,15 @@ class Xula(_fpga):
     _name = 'xula'
 
     default_clocks = {
-        'clock': dict(freqeuncy=12e6, pins=(43,)),
+        'clock': dict(frequency=12e6, pins=(43,)),
         'chan_clk' : dict(frequency=1e6, pins=(44,))
     }
 
     default_ports = {
-        'chan' : dict(pins=(36,37,39,50,52,56,57,61,  # 0-7
-                            62,68,72,73,82,83,84,35,  # 8-15
-                            34,33,32,21,20,19,13,12,  # 17-23
-                            07,04,03,97,94,93,89,88)) # 24-31
-
-        
+        'chan' : dict(pins=(36, 37, 39, 50, 52, 56, 57, 61,  # 0-7
+                            62, 68, 72, 73, 82, 83, 84, 35,  # 8-15
+                            34, 33, 32, 21, 20, 19, 13, 12,  # 17-23
+                            7, 4, 3, 97, 94, 93, 89, 88)) # 24-31
     }
 
     def get_flow(self, top=None):
@@ -47,86 +45,86 @@ class Xula(_fpga):
 
 
 class Xula2(_fpga):
-      vendor = 'xilinx'
-      family = 'spartan6'
-      device = 'XC6SLX25'
-      package = 'FTG256'
-      speed = '-2'
-      _name = 'xula2'
+    vendor = 'xilinx'
+    family = 'spartan6'
+    device = 'XC6SLX25'
+    package = 'FTG256'
+    speed = '-2'
+    _name = 'xula2'
 
-      default_clocks = {
-          'clock': dict(frequency=12e6, pins=('A9',)),
-          'chan_clk': dict(frequency=1e6, pins=('T7'))
-      }
+    default_clocks = {
+        'clock': dict(frequency=12e6, pins=('A9',)),
+        'chan_clk': dict(frequency=1e6, pins=('T7'))
+    }
 
-      default_ports = {
-          'chan': dict(pins=('R7','R15','R16','M15','M16','K15',  #0-5
-                             'K16','J16','J14','F15','F16','C16', #6-11
-                             'C15','B16','B15','T4','R2','R1',    #12-17
-                             'M2','M1','K3','J4','H1','H2',       #18-23
-                             'F1','F2','E1','E2','C1','B1',       #24-29
-                             'B2','A2',) )
-      }
-
-
-      default_extintf = {
-          #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          # VGA:
-          'vga': None,  
- 
-          #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          # SDRAM: the Xula2 has a 256Mbit WINBond SDRAM,
-          # http://www.winbond.com/hq/enu/ProductAndSales/ProductLines/SpecialtyDRAM/SDRAM/W9825G6JH.htm
-          'sdram': SDRAM(
-              Port('addr', pins=('E4',  'E3',  'D3',  'C3',   # 0-3
-                                 'B12', 'A12', 'D12', 'E12',  # 4-7
-                                 'G16', 'G12', 'F4',  'G11',  # 8-11
-                                 'H13',)                      # 12
-                   ),
-              Port('data', pins=('P6',  'T6',  'T5',  'P5',   # 0-3
-                                 'R5',  'N5',  'P4',  'N4',   # 4-7
-                                 'P12', 'R12', 'T13', 'T14',  # 8-11
-                                 'R14', 'T15', 'T12', 'P11',) # 12-15
-               ),
-              Port('bs',   pins=('H3', 'G3',) ),
-              Port('cas',  pins=('L3',) ),
-              Port('ras',  pins=('L4',) ),
-              Port('ldqm', pins=('M4',) ),
-              Port('udqm', pins=('L13',) ),
-              Port('clk',  pins=('K12',) ),
-              Port('clkfb', pins=('K11',) ),
-              Port('cs', pins=('H4',) ),
-              Port('we', pins=('M3',) ),
-              Port('cke',  pins=('J12',)),
-              
-              # timing information, all in ns
-              timing = dict(
-                  init = 200000.0,
-                  ras  = 45.0,
-                  rcd  = 20.0,
-                  ref  = 64000000.0,
-                  rfc  = 65.0,
-                  rp   = 20.0,
-                  xsr  = 75.0                  
-               ),
-              ddr = 0  # single data rate
-          ),
-
-          #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          #  SPI and MicroSD
-          #'flash': _extintf(
-          #    Port('sclk', pins=()),
-          #    Port('sdi', pins=()),
-          #    Port('sdo', pins=()),
-          #    port('cs', pins=()),
-          #    ),
-          #
-          #'microsd' : None,
-
-          #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          # 
-      }
+    default_ports = {
+        'chan': dict(pins=('R7','R15','R16','M15','M16','K15',  #0-5
+                           'K16','J16','J14','F15','F16','C16', #6-11
+                           'C15','B16','B15','T4','R2','R1',    #12-17
+                           'M2','M1','K3','J4','H1','H2',       #18-23
+                           'F1','F2','E1','E2','C1','B1',       #24-29
+                           'B2','A2',) )
+    }
 
 
-      def get_flow(self, top=None):
-          return ISE(brd=self, top=top)
+    default_extintf = {
+        #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        # VGA:
+        'vga': None,  
+
+        #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        # SDRAM: the Xula2 has a 256Mbit WINBond SDRAM,
+        # http://www.winbond.com/hq/enu/ProductAndSales/ProductLines/SpecialtyDRAM/SDRAM/W9825G6JH.htm
+        'sdram': SDRAM(
+            Port('addr', pins=('E4',  'E3',  'D3',  'C3',   # 0-3
+                               'B12', 'A12', 'D12', 'E12',  # 4-7
+                               'G16', 'G12', 'F4',  'G11',  # 8-11
+                               'H13',)                      # 12
+                 ),
+            Port('data', pins=('P6',  'T6',  'T5',  'P5',   # 0-3
+                               'R5',  'N5',  'P4',  'N4',   # 4-7
+                               'P12', 'R12', 'T13', 'T14',  # 8-11
+                               'R14', 'T15', 'T12', 'P11',) # 12-15
+             ),
+            Port('bs',   pins=('H3', 'G3',) ),
+            Port('cas',  pins=('L3',) ),
+            Port('ras',  pins=('L4',) ),
+            Port('ldqm', pins=('M4',) ),
+            Port('udqm', pins=('L13',) ),
+            Port('clk',  pins=('K12',) ),
+            Port('clkfb', pins=('K11',) ),
+            Port('cs', pins=('H4',) ),
+            Port('we', pins=('M3',) ),
+            Port('cke',  pins=('J12',)),
+            
+            # timing information, all in ns
+            timing = dict(
+                init = 200000.0,
+                ras  = 45.0,
+                rcd  = 20.0,
+                ref  = 64000000.0,
+                rfc  = 65.0,
+                rp   = 20.0,
+                xsr  = 75.0                  
+             ),
+            ddr = 0  # single data rate
+        ),
+
+        #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        #  SPI and MicroSD
+        #'flash': _extintf(
+        #    Port('sclk', pins=()),
+        #    Port('sdi', pins=()),
+        #    Port('sdo', pins=()),
+        #    port('cs', pins=()),
+        #    ),
+        #
+        #'microsd' : None,
+
+        #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        # 
+    }
+
+
+    def get_flow(self, top=None):
+        return ISE(brd=self, top=top)

--- a/gizflo/extintf/__init__.py
+++ b/gizflo/extintf/__init__.py
@@ -1,4 +1,4 @@
 
-from _port import Port 
-from _clock import Clock
-from _reset import Reset
+from ._port import Port
+from ._clock import Clock
+from ._reset import Reset

--- a/gizflo/extintf/_sdram.py
+++ b/gizflo/extintf/_sdram.py
@@ -1,6 +1,6 @@
 
-from _clock import Clock
-from _extintf import _extintf
+from ._clock import Clock
+from ._extintf import _extintf
 
 class SDRAM(_extintf):
     """
@@ -50,7 +50,7 @@ class SDRAM(_extintf):
     def __init__(self, *ports, **params):
 
         # is this DDR SDRAM or SDR SDRAM (ddr=0)
-        if params.has_key('ddr'):
+        if 'ddr' in params:
             self.ddr = params['ddr']
         else:
             self.ddr = 0
@@ -66,9 +66,5 @@ class SDRAM(_extintf):
         # update any of the timing information
         self._timing = dict(self.default_timing)
         for k,v in params.items():
-            if self._timing.has_key(k):
+            if k in self._timing:
                 self._timing[k] = v
-        
-
-    
-    

--- a/gizflo/toolchain/__init__.py
+++ b/gizflo/toolchain/__init__.py
@@ -1,5 +1,5 @@
 
-from altera import Quartus
-from xilinx import ISE
+from .altera import Quartus
+from .xilinx import ISE
 #from xilinx import Vivado
 #from lattice import Diamond

--- a/gizflo/toolchain/_convert.py
+++ b/gizflo/toolchain/_convert.py
@@ -78,7 +78,7 @@ def convert(brd, top=None, name=None, use='verilog', path='.'):
             print('   moving %s --> %s'%(src, path))
             try:
                 shutil.move(src, path)
-            except Exception,err:
+            except Exception as err:
                 print("skipping %s because %s" % (src, err,))
 
     if use.lower() == 'verilog':

--- a/gizflo/toolchain/altera/__init__.py
+++ b/gizflo/toolchain/altera/__init__.py
@@ -1,2 +1,2 @@
 
-from _quartus import Quartus
+from ._quartus import Quartus

--- a/gizflo/toolchain/altera/_quartus.py
+++ b/gizflo/toolchain/altera/_quartus.py
@@ -28,8 +28,8 @@ from .._convert import convert
 from ..._fpga import _fpga
 from ...extintf import Clock
 
-from _quartus_parse_reports import get_utilization
-from _quartus_parse_reports import get_fmax
+from ._quartus_parse_reports import get_utilization
+from ._quartus_parse_reports import get_fmax
 
 _default_pin_attr = {
     '': None,
@@ -193,7 +193,7 @@ class Quartus(_toolflow):
                                   stderr=subprocess.STDOUT,
                                   stdout=logfile)
             logfile.close()
-        except Exception, err:
+        except Exception as err:
             print(err)
             raise err
 

--- a/gizflo/toolchain/xilinx/__init__.py
+++ b/gizflo/toolchain/xilinx/__init__.py
@@ -1,2 +1,2 @@
 
-from _ise import ISE
+from ._ise import ISE

--- a/gizflo/toolchain/xilinx/_ise.py
+++ b/gizflo/toolchain/xilinx/_ise.py
@@ -26,7 +26,7 @@ from .._toolflow import _toolflow
 from .._convert import convert
 from ..._fpga import _fpga
 from ...extintf import Clock
-from _ise_parse_reports import get_utilization
+from ._ise_parse_reports import get_utilization
 
 _default_pin_attr = {
     'NET': None,
@@ -215,7 +215,7 @@ class ISE(_toolflow):
                                   stderr=subprocess.STDOUT,
                                   stdout=logfile)
             logfile.close()
-        except Exception, err:
+        except Exception as err:
             print(err)
             raise err
 


### PR DESCRIPTION
I managed to install gizflo on my machine, antergos based python 3.4.3, with minor modifications:
- Fixed relative imports
- Xula 2 pin dictionary modified removing leading zeros
- Exception catch
- Change .haskey method for in 
  I don't have any of the boards here to test. The examples may need some fix to run on python 3.4.
